### PR TITLE
Fix undefined property notice

### DIFF
--- a/src/WebAPI/OData/Client.php
+++ b/src/WebAPI/OData/Client.php
@@ -340,7 +340,7 @@ class Client {
                 $result->List = array_merge( $result->List, $data->value );
                 $result->Count = count( $result->List );
 
-                $nextLink     = $data->{Annotation::ODATA_NEXTLINK};
+                $nextLink     = $data->{Annotation::ODATA_NEXTLINK} ?? null;
             }
 
             unset( $result->SkipToken );


### PR DESCRIPTION
In a Symfony app with the default error handler, the following notice is converted to an exception and stops command execution:

> Notice: Undefined property: stdClass::$@odata.nextLink

This ensures `$nextLink` is `null` when the property does not exist.