### PR TITLE
Fix an uninitilized typed property

### DIFF
--- a/src/WebAPI/OData/Settings.php
+++ b/src/WebAPI/OData/Settings.php
@@ -57,7 +57,7 @@ abstract class Settings implements LoggerAwareInterface {
      *
      * If no path is specified and peer verification is enabled, default CA bundle will be used if available.
      */
-    public ?string $caBundlePath;
+    public ?string $caBundlePath = null;
 
     /**
      * Whether to perform peer verification.


### PR DESCRIPTION
A missing initialization of `Settings::caBundlePath` causes an exception when using `createOnlineClient()`.