### PR TITLE
Allow empty baseType in MetaData

### DIFF
--- a/src/WebAPI/OData/Metadata.php
+++ b/src/WebAPI/OData/Metadata.php
@@ -152,7 +152,9 @@ class Metadata {
             $metadata->entityMaps[$typeName] = $newMap;
 
             $baseType = $metadata->entityMaps[$newMap->baseEntity];
-            $metadata->entityMaps[$typeName]->rebuildFromBase( $baseType );
+            if ($baseType !== null) {
+                $metadata->entityMaps[$typeName]->rebuildFromBase( $baseType );
+            }
         }
 
         /*


### PR DESCRIPTION
I have a case where a entity type doesn't have any base type.

This results in an error as the parameter from rebuildFromBase is not nullable.

This PR fixes this issue.