### PR TITLE
Update AttributeState.php

### DIFF
--- a/src/Xrm/AttributeState.php
+++ b/src/Xrm/AttributeState.php
@@ -33,7 +33,7 @@ class AttributeState implements \ArrayAccess, \IteratorAggregate {
     /**
      * @var array
      */
-    protected array $attributes;
+    protected array $attributes = [];
 
     public function reset(): void {
         foreach ( $this->attributes as $attribute => &$state ) {


### PR DESCRIPTION
In AttributeState.php line 94:
                                                                                                      
  Typed property AlexaCRM\Xrm\AttributeState::$attributes must not be accessed before initialization