### PR TITLE
PHP 8.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
   "prefer-stable": true,
   "require": {
     "php": "^8.0",
-    "psr/log": "^1.0 || ^2.0 || ^3.0",
-    "psr/cache": "^1.0 || ^2.0 || ^3.0",
+    "psr/log": "^2.0 || ^3.0",
+    "psr/cache": "^2.0 || ^3.0",
     "elao/enum": "^1.6",
     "alexacrm/strong-serializer": "^2.0",
     "guzzlehttp/guzzle": "^6.5 || ^7.0"

--- a/src/Cache/NullAdapter.php
+++ b/src/Cache/NullAdapter.php
@@ -45,7 +45,7 @@ class NullAdapter implements CacheItemPoolInterface {
      * @return CacheItemInterface
      *   The corresponding Cache Item.
      */
-    public function getItem( $key ) {
+    public function getItem( string $key ): CacheItemInterface {
         return new NullCacheItem( $key );
     }
 
@@ -59,13 +59,13 @@ class NullAdapter implements CacheItemPoolInterface {
      *   If any of the keys in $keys are not a legal value a \Psr\Cache\InvalidArgumentException
      *   MUST be thrown.
      *
-     * @return array|\Traversable
-     *   A traversable collection of Cache Items keyed by the cache keys of
+     * @return iterable
+     *   An iterable collection of Cache Items keyed by the cache keys of
      *   each item. A Cache item will be returned for each key, even if that
      *   key is not found. However, if no keys are specified then an empty
      *   traversable MUST be returned instead.
      */
-    public function getItems( array $keys = [] ) {
+    public function getItems(array $keys = []): iterable {
         $items = [];
         foreach ( $keys as $key ) {
             $items[] = new NullCacheItem( $key );
@@ -91,7 +91,7 @@ class NullAdapter implements CacheItemPoolInterface {
      * @return bool
      *   True if item exists in the cache, false otherwise.
      */
-    public function hasItem( $key ) {
+    public function hasItem( string $key ): bool {
         return false;
     }
 
@@ -101,7 +101,7 @@ class NullAdapter implements CacheItemPoolInterface {
      * @return bool
      *   True if the pool was successfully cleared. False if there was an error.
      */
-    public function clear() {
+    public function clear(): bool {
         return true;
     }
 
@@ -118,7 +118,7 @@ class NullAdapter implements CacheItemPoolInterface {
      * @return bool
      *   True if the item was successfully removed. False if there was an error.
      */
-    public function deleteItem( $key ) {
+    public function deleteItem( string $key ): bool {
         return true;
     }
 
@@ -135,7 +135,7 @@ class NullAdapter implements CacheItemPoolInterface {
      * @return bool
      *   True if the items were successfully removed. False if there was an error.
      */
-    public function deleteItems( array $keys ) {
+    public function deleteItems( array $keys ): bool {
         return true;
     }
 
@@ -148,7 +148,7 @@ class NullAdapter implements CacheItemPoolInterface {
      * @return bool
      *   True if the item was successfully persisted. False if there was an error.
      */
-    public function save( CacheItemInterface $item ) {
+    public function save( CacheItemInterface $item ): bool {
         return true;
     }
 
@@ -161,7 +161,7 @@ class NullAdapter implements CacheItemPoolInterface {
      * @return bool
      *   False if the item could not be queued or if a commit was attempted and failed. True otherwise.
      */
-    public function saveDeferred( CacheItemInterface $item ) {
+    public function saveDeferred( CacheItemInterface $item ): bool {
         return true;
     }
 
@@ -171,7 +171,7 @@ class NullAdapter implements CacheItemPoolInterface {
      * @return bool
      *   True if all not-yet-saved items were successfully saved or there were none. False otherwise.
      */
-    public function commit() {
+    public function commit(): bool {
         return true;
     }
 

--- a/src/Cache/NullCacheItem.php
+++ b/src/Cache/NullCacheItem.php
@@ -30,14 +30,14 @@ class NullCacheItem implements CacheItemInterface {
     /**
      * @var string
      */
-    protected $key;
+    protected string $key;
 
     /**
      * NullCacheItem constructor.
      *
      * @param string $key
      */
-    public function __construct( $key ) {
+    public function __construct( string $key ) {
         $this->key = $key;
     }
 
@@ -50,7 +50,7 @@ class NullCacheItem implements CacheItemInterface {
      * @return string
      *   The key string for this cache item.
      */
-    public function getKey() {
+    public function getKey(): string {
         return $this->key;
     }
 
@@ -66,7 +66,7 @@ class NullCacheItem implements CacheItemInterface {
      * @return mixed
      *   The value corresponding to this cache item's key, or null if not found.
      */
-    public function get() {
+    public function get(): mixed {
         return null;
     }
 
@@ -79,7 +79,7 @@ class NullCacheItem implements CacheItemInterface {
      * @return bool
      *   True if the request resulted in a cache hit. False otherwise.
      */
-    public function isHit() {
+    public function isHit(): bool {
         return false;
     }
 
@@ -96,7 +96,7 @@ class NullCacheItem implements CacheItemInterface {
      * @return static
      *   The invoked object.
      */
-    public function set( $value ) {
+    public function set( mixed $value ): static {
         return $this;
     }
 
@@ -112,7 +112,7 @@ class NullCacheItem implements CacheItemInterface {
      * @return static
      *   The called object.
      */
-    public function expiresAt( $expiration ) {
+    public function expiresAt( ?\DateTimeInterface $expiration ): static {
         return $this;
     }
 
@@ -129,7 +129,7 @@ class NullCacheItem implements CacheItemInterface {
      * @return static
      *   The called object.
      */
-    public function expiresAfter( $time ) {
+    public function expiresAfter( int|\DateInterval|null $time ): static {
         return $this;
     }
 }

--- a/src/Cache/NullCacheItem.php
+++ b/src/Cache/NullCacheItem.php
@@ -26,19 +26,12 @@ use Psr\Cache\CacheItemInterface;
  * Represents a PSR-6 compliant dummy cache item.
  */
 class NullCacheItem implements CacheItemInterface {
-
-    /**
-     * @var string
-     */
-    protected string $key;
-
     /**
      * NullCacheItem constructor.
      *
      * @param string $key
      */
-    public function __construct( string $key ) {
-        $this->key = $key;
+    public function __construct( protected string $key ) {
     }
 
     /**

--- a/src/Xrm/AttributeState.php
+++ b/src/Xrm/AttributeState.php
@@ -59,7 +59,7 @@ class AttributeState implements \ArrayAccess, \IteratorAggregate {
      *
      * @return mixed Can return all value types.
      */
-    public function offsetGet( $offset ) {
+    public function offsetGet( $offset ): mixed {
         return array_key_exists( $offset, $this->attributes ) && $this->attributes[$offset] === true;
     }
 

--- a/src/Xrm/Entity.php
+++ b/src/Xrm/Entity.php
@@ -165,7 +165,7 @@ class Entity implements \ArrayAccess {
      *
      * @return mixed Can return all value types.
      */
-    public function offsetGet( $offset ) {
+    public function offsetGet( $offset ): mixed {
         return $this->GetAttributeValue( $offset );
     }
 

--- a/src/Xrm/EntityCollection.php
+++ b/src/Xrm/EntityCollection.php
@@ -61,9 +61,9 @@ class EntityCollection implements \Iterator {
     /**
      * Return the current element.
      *
-     * @return mixed
+     * @return Entity|bool
      */
-    public function current() {
+    public function current(): Entity|bool {
         return current( $this->Entities );
     }
 
@@ -77,9 +77,9 @@ class EntityCollection implements \Iterator {
     /**
      * Return the key of the current element.
      *
-     * @return mixed Scalar on success, or null on failure.
+     * @return string|int|null Scalar on success, or null on failure.
      */
-    public function key() {
+    public function key(): string|int|null {
         return key( $this->Entities );
     }
 


### PR DESCRIPTION
Last commit was to have compatibility with PSR cache & log versions ^3.0. They require PHP >8.0. They also introduced typed parameters and return types. This PR comes with fixing the crashes due to incompatibility

```
Fatal error:  Declaration of AlexaCRM\Cache\NullAdapter: :getItem($key) must be compatible with Psr\Cache\CacheItemPoolInterface: :getItem(string $key): Psr\Cache\CacheItemInterface in /srv/app/vendor/alexacrm/dynamics-webapi-toolkit/src/Cache/NullAdapter.php on line 48
```