### PR TITLE
Update composer.json to allow psr/log 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "minimum-stability": "dev",
   "require": {
     "php": "^7.4 || ^8.0",
-    "psr/log": "^1.0 || ^2.0",
+    "psr/log": "^1.0 || ^2.0 || ^3.0",
     "psr/cache": "^1.0 || ^2.0",
     "elao/enum": "^1.6",
     "alexacrm/strong-serializer": "^2.0",


### PR DESCRIPTION
For example, I am using this library in a Drupal 10 project, which has a dependency on psr/log 3.0