### PR TITLE
Feat Configure OData annotations

### DIFF
--- a/src/WebAPI/OData/Client.php
+++ b/src/WebAPI/OData/Client.php
@@ -340,7 +340,7 @@ class Client {
 
             if ( isset( $queryOptions['IncludeAnnotations'] ) ) {
                 if( $queryOptions['IncludeAnnotations'] === false ) {
-                    unset( $prefer['IncludeAnnotations'] );
+                    $prefer['IncludeAnnotations'] = 'odata.include-annotations="-*"';
                 }
                 else {
                     $prefer['IncludeAnnotations'] = 'odata.include-annotations="' . $queryOptions['IncludeAnnotations'] . '"';

--- a/src/WebAPI/OData/Client.php
+++ b/src/WebAPI/OData/Client.php
@@ -329,16 +329,26 @@ class Client {
      */
     private function buildQueryHeaders( array $queryOptions = null ): array {
         $headers = [];
-        $prefer = [];
+        $prefer = [
+            'IncludeAnnotations' => 'odata.include-annotations="*"'
+        ];
 
         if ( $queryOptions != null ) {
             if ( isset( $queryOptions['MaxPageSize'] ) ) {
                 $prefer[] = 'odata.maxpagesize=' . $queryOptions['MaxPageSize'];
             }
+
+            if ( isset( $queryOptions['IncludeAnnotations'] ) ) {
+                if( $queryOptions['IncludeAnnotations'] === false ) {
+                    unset( $prefer['IncludeAnnotations'] );
+                }
+                else {
+                    $prefer['IncludeAnnotations'] = 'odata.include-annotations="' . $queryOptions['IncludeAnnotations'] . '"';
+                }
+            }
         }
 
-        $prefer[] = 'odata.include-annotations="*"';
-        $headers['Prefer'] = implode( ',', $prefer );
+        $headers['Prefer'] = implode( ',', array_values($prefer) );
 
         return $headers;
     }


### PR DESCRIPTION
Add in the ability to set the odata.include-annotations header using the queryOptions array.

Setting key: IncludeAnnotations
Setting values: false | string
See string settings for annotations: https://learn.microsoft.com/en-us/odata/webapi/include-annotations

This provides the option to exclude annotations or limit it to a specific set of annotations. 
The default is to include annotations so existing behavior has been maintained.

Exclude annotations
`
$client->getList('entityname', ['IncludeAnnotations' => false]);
`

Limit annotations to any starting with "OData.Community.Display"
`
$client->getList('entityname', ['IncludeAnnotations' => 'OData.Community.Display.*']);
`