### PR TITLE
Fix to NullCacheItem throws error on PHP 8.2 and 8.3 as methods do not math interface implemented.

### DIFF
--- a/src/Cache/NullCacheItem.php
+++ b/src/Cache/NullCacheItem.php
@@ -66,7 +66,7 @@ class NullCacheItem implements CacheItemInterface {
      * @return mixed
      *   The value corresponding to this cache item's key, or null if not found.
      */
-    public function get() {
+    public function get(): mixed {
         return null;
     }
 
@@ -96,7 +96,7 @@ class NullCacheItem implements CacheItemInterface {
      * @return static
      *   The invoked object.
      */
-    public function set($value) {
+    public function set(mixed $value): static {
         return $this;
     }
 
@@ -112,7 +112,7 @@ class NullCacheItem implements CacheItemInterface {
      * @return static
      *   The called object.
      */
-    public function expiresAt($expiration) {
+    public function expiresAt(?\DateTimeInterface $expiration): static {
         return $this;
     }
 
@@ -129,7 +129,7 @@ class NullCacheItem implements CacheItemInterface {
      * @return static
      *   The called object.
      */
-    public function expiresAfter($time) {
+    public function expiresAfter(int|\DateInterval|null $time): static {
         return $this;
     }
 }


### PR DESCRIPTION
### Problem:
The library throws error in installation on Laravel with PHP 8.2 and 8.3. The error is thrown as methods:
-get()
-set()
-expiresAt()
-expiresAfter()
Do not match with their Interface CacheItemInterface declaration. In the Interface, the methods are created with params and return types declared, which is not done in the Class.
This adds the type to params and return values of the functions


### The following methods were updated:


```
public function get(): mixed

public function set(mixed $value): static

public function expiresAt(?\DateTimeInterface $expiration): static

public function expiresAfter(int|\DateInterval|null $time): static
```